### PR TITLE
Update gps.h

### DIFF
--- a/gps.h
+++ b/gps.h
@@ -1,8 +1,11 @@
 #ifndef GPS_H
 #define GPS_H
+
 #include <time.h>
+
 struct gps_instance_t;
 typedef struct gps_instance_t* gps_t;
+
 typedef enum {
   GPS_NO_ERROR = 0,
   GPS_INVALID_CHECKSUM,
@@ -12,11 +15,13 @@ typedef enum {
   GPS_NO_TIME = 33,
   GPS_NO_FIX_TYPE = 34,
 } gps_error_code_t;
+
 gps_t gps_init();
 gps_error_code_t gps_destroy(gps_t gps_instance);
 gps_error_code_t gps_update(gps_t gps_instance, const char* sentence, int len);
-gps_error_code_t gps_get_lat_lon(gps_t gps_instance, int* degmin, int* minfrac);
+gps_error_code_t gps_get_lat_lon(gps_t gps_instance, int* degmin, int* minfrac, char* lat_hemi, char* lon_hemi);
 gps_error_code_t gps_get_time(gps_t gps_instance, struct tm* time);
 gps_error_code_t gps_get_altitude(gps_t gps_instance, float* msl_metres);
 gps_error_code_t gps_get_geoid_sep(gps_t gps_instance, float* geoid_sep_metres);
+
 #endif


### PR DESCRIPTION
This pull request enhances the GPS library functionality by adding support for hemisphere indicators in the latitude and longitude values returned by the gps_get_lat_lon function. Previously, the library provided latitude and longitude values without indicating whether they were North, South, East, or West.

To address this limitation, the gps_get_lat_lon function has been updated to accept additional parameters, char* lat_hemi and char* lon_hemi, which will store the hemisphere indicators for latitude and longitude respectively. These indicators will provide crucial information about the direction of the coordinates.

Furthermore, test cases have been added to ensure that the hemisphere indicators are correctly returned along with the latitude and longitude values, preventing any recurrence of this issue in the future.

Name:Palash Shah
Reg No:RA2211003010949
I/II/III Year:II
SRMIST email:ps9600@srmist.edu.in

